### PR TITLE
chore: use camunda artifactory url

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@
         <repository>
             <id>camunda-bpm-nexus-ee</id>
             <name>camunda-bpm-nexus</name>
-            <url>https://camunda.jfrog.io/artifactory/private/</url>
+            <url>https://artifacts.camunda.com/artifactory/private/</url>
         </repository>
     </repositories>
 </project>


### PR DESCRIPTION
Related to: INFRA-3110

It uses the unified artifacts domain.